### PR TITLE
actions: setup image and Helm chart publishing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -106,7 +106,7 @@ jobs:
             linux/arm64
 
       - name: Build and publish the Helm chart
-        working-directory: helm
+        working-directory: charts/eks-pod-identity-agent
         env:
           EVENT_TYPE: ${{ (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') && 'tag' ) || 'commit' ) || 'dispatch'}}
           IMAGE_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,143 @@
+name: Build and publish release artifacts
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run tets
+        run: make test
+      - name: Build helm chart
+        working-directory: charts/eks-pod-identity-agent
+        run: helm package . --version "1.2.3-dev" --app-version "4.5.6-dev"
+
+  build-and-push:
+    name: Build and push Docker container
+    runs-on: ubuntu-latest
+    needs: [test]
+    environment: release
+    env:
+      AWS_REGION_PRIVATE: us-west-2
+      AWS_REGION_PUBLIC: us-east-1
+    permissions:
+      contents: read
+      id-token: write # This is required for requesting the JWT, see https://github.com/aws-actions/configure-aws-credentials#OIDC
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        
+      - name: Configure AWS credentials for ECR Private
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION_PRIVATE }}
+          role-to-assume: ${{ env.ECR_ROLE }}
+          mask-aws-account-id: 'no'
+
+      - name: Configure AWS credentials for ECR Public
+        if: "startsWith(github.ref, 'refs/tags/v')"
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION_PUBLIC }}
+          role-to-assume: ${{ env.ECR_ROLE }}
+          mask-aws-account-id: 'no'
+
+      - name: Login to Amazon ECR Private
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Login to Amazon ECR Public
+        if: "startsWith(github.ref, 'refs/tags/v')"
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Prepare docker labels and tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # enable public repo only for tags
+          images: |
+            name=${{ steps.login-ecr.outputs.registry }}/${{ github.repository }},enable=true
+            name=${{ steps.login-ecr-public.outputs.registry }}/${{ github.repository }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+          flavor: |
+            latest=false
+          # Enable sha tag on branch push events and workflow dispatches.
+          # Enable semver tags on tag push events, but don't overwrite major/minor tags for prereleases.
+          tags: |
+            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDDTHHmmss'}},format=short,enable=${{ startsWith(github.ref, 'refs/heads/') }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+  
+      - name: Build the Docker image and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: |
+            linux/amd64
+            linux/arm64
+
+      - name: Build and publish the Helm chart
+        working-directory: helm
+        env:
+          EVENT_TYPE: ${{ (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') && 'tag' ) || 'commit' ) || 'dispatch'}}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          # Determine chart version to set
+          case "${EVENT_TYPE}" in
+            tag)
+              CHART_VERSION="${GITHUB_REF_NAME}"
+              ;;
+            commit)
+              ;&
+            dispatch)
+              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*")"
+              ;;
+            *)
+              echo "Unknown event type '${EVENT_TYPE}', workflow bug?" >&2
+              exit 1
+              ;;
+          esac
+
+          # Trim `v` prefix if exists
+          CHART_VERSION=${CHART_VERSION#v}
+          IMAGE_VERSION=${IMAGE_VERSION#v}
+
+          # Build/package the chart
+          echo "Setting chart version to ${CHART_VERSION} and image version to ${IMAGE_VERSION}"
+          helm package . --version "${CHART_VERSION}" --app-version "${IMAGE_VERSION}"
+          ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
+
+          # Publish the chart
+          helm push "$ARTIFACT_NAME" "oci://$HELM_PRIVATE_ECR_REPO"
+          if [[ "$EVENT_TYPE" == "tag" ]]; then
+            helm push "$ARTIFACT_NAME" "oci://$HELM_PUBLIC_ECR_REPO"
+          fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,7 +48,6 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         
       - name: Configure AWS credentials for ECR Private
-        if: "!startsWith(github.ref, 'refs/tags/v')"
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ env.AWS_REGION_PRIVATE }}
@@ -64,7 +63,6 @@ jobs:
           mask-aws-account-id: 'no'
 
       - name: Login to Amazon ECR Private
-        if: "!startsWith(github.ref, 'refs/tags/v')"
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,28 +48,26 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         
       - name: Configure AWS credentials for ECR Private
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           aws-region: ${{ env.AWS_REGION_PRIVATE }}
           role-to-assume: ${{ env.ECR_ROLE }}
-          mask-aws-account-id: 'no'
 
       - name: Configure AWS credentials for ECR Public
         if: "startsWith(github.ref, 'refs/tags/v')"
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           aws-region: ${{ env.AWS_REGION_PUBLIC }}
           role-to-assume: ${{ env.ECR_ROLE }}
-          mask-aws-account-id: 'no'
 
       - name: Login to Amazon ECR Private
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
       - name: Login to Amazon ECR Public
         if: "startsWith(github.ref, 'refs/tags/v')"
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
         with:
           registry-type: public
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
@@ -40,12 +40,12 @@ jobs:
       id-token: write # This is required for requesting the JWT, see https://github.com/aws-actions/configure-aws-credentials#OIDC
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
 
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
         
       - name: Configure AWS credentials for ECR Private
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
@@ -73,7 +73,7 @@ jobs:
 
       - name: Prepare docker labels and tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
         with:
           # enable public repo only for tags
           images: |
@@ -90,7 +90,7 @@ jobs:
             type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
   
       - name: Build the Docker image and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### Summary

Configure CI/CD build for docker images and helm charts.

Mostly copied from [aws-quota-checker](https://github.com/gravitational/aws-quota-checker/blob/teleport/.github/workflows/cd.yml) repo with small modifications.

Every commit to `main` is released to private repo, while only tags are released public repo.


### Testing

Not tested, need to merge to main first to be able to dispatch the workflow
