### PR TITLE
actions: Fix push jobs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,6 +6,15 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      deploy_env:
+        description: "Select staging or production release"
+        default: staging
+        required: false
+        type: choice
+        options:
+          - staging # build and push artifacts to staging repos
+          - release # build and push artifacts to release repos
 
 permissions:
   contents: read
@@ -32,7 +41,7 @@ jobs:
     name: Build and push Docker container and Helm Charts
     runs-on: ubuntu-latest
     needs: [test]
-    environment: release
+    environment: ${{ inputs.deploy_env || 'release' }}
     env:
       AWS_REGION_PRIVATE: us-west-2
       AWS_REGION_PUBLIC: us-east-1

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -144,8 +144,7 @@ jobs:
           ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
 
           # Publish the chart
-          # helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PRIVATE_ECR_REPO }}"
-          helm push "$ARTIFACT_NAME" "oci://603330915152.dkr.ecr.us-west-2.amazonaws.com/gravitational/charts/"
+          helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PRIVATE_ECR_REPO }}"
           if [[ "$EVENT_TYPE" == "tag" ]]; then
             helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PUBLIC_ECR_REPO }} "
           fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,7 +14,7 @@ on:
         type: choice
         options:
           - staging # build and push artifacts to staging repos
-          - release # build and push artifacts to release repos
+          - release # build and push artifacts to release repos (works only for main branch)
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
         run: helm package . --version "1.2.3-dev" --app-version "4.5.6-dev"
 
   build-and-push:
-    name: Build and push Docker container and Helm Charts
+    name: Build and push Docker image and Helm chart
     runs-on: ubuntu-latest
     needs: [test]
     environment: ${{ inputs.deploy_env || 'release' }}
@@ -125,7 +125,7 @@ jobs:
             commit)
               ;&
             dispatch)
-              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*")"
+              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*" || true)"
               ;;
             *)
               echo "Unknown event type '${EVENT_TYPE}', workflow bug?" >&2
@@ -136,6 +136,7 @@ jobs:
           # Trim `v` prefix if exists
           CHART_VERSION=${CHART_VERSION#v}
           IMAGE_VERSION=${IMAGE_VERSION#v}
+          CHART_VERSION=${CHART_VERSION:-0.0.0-${IMAGE_VERSION}}
 
           # Build/package the chart
           echo "Setting chart version to ${CHART_VERSION} and image version to ${IMAGE_VERSION}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -144,7 +144,8 @@ jobs:
           ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
 
           # Publish the chart
-          helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PRIVATE_ECR_REPO }}"
+          # helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PRIVATE_ECR_REPO }}"
+          helm push "$ARTIFACT_NAME" "oci://603330915152.dkr.ecr.us-west-2.amazonaws.com/gravitational/charts/"
           if [[ "$EVENT_TYPE" == "tag" ]]; then
             helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PUBLIC_ECR_REPO }} "
           fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    name: Test application and helm chart
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -28,7 +29,7 @@ jobs:
         run: helm package . --version "1.2.3-dev" --app-version "4.5.6-dev"
 
   build-and-push:
-    name: Build and push Docker container
+    name: Build and push Docker container and Helm Charts
     runs-on: ubuntu-latest
     needs: [test]
     environment: release
@@ -51,14 +52,14 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           aws-region: ${{ env.AWS_REGION_PRIVATE }}
-          role-to-assume: ${{ env.ECR_ROLE }}
+          role-to-assume: ${{ vars.ECR_ROLE }}
 
       - name: Configure AWS credentials for ECR Public
         if: "startsWith(github.ref, 'refs/tags/v')"
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           aws-region: ${{ env.AWS_REGION_PUBLIC }}
-          role-to-assume: ${{ env.ECR_ROLE }}
+          role-to-assume: ${{ vars.ECR_ROLE }}
 
       - name: Login to Amazon ECR Private
         id: login-ecr
@@ -77,8 +78,8 @@ jobs:
         with:
           # enable public repo only for tags
           images: |
-            name=${{ steps.login-ecr.outputs.registry }}/${{ github.repository }},enable=true
-            name=${{ steps.login-ecr-public.outputs.registry }}/${{ github.repository }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+            name=${{ vars.PRIVATE_ECR_REPO }},enable=true
+            name=${{ vars.PUBLIC_ECR_REPO }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           flavor: |
             latest=false
           # Enable sha tag on branch push events and workflow dispatches.
@@ -133,7 +134,7 @@ jobs:
           ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
 
           # Publish the chart
-          helm push "$ARTIFACT_NAME" "oci://$HELM_PRIVATE_ECR_REPO"
+          helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PRIVATE_ECR_REPO }}"
           if [[ "$EVENT_TYPE" == "tag" ]]; then
-            helm push "$ARTIFACT_NAME" "oci://$HELM_PUBLIC_ECR_REPO"
+            helm push "$ARTIFACT_NAME" "oci://${{ vars.HELM_PUBLIC_ECR_REPO }} "
           fi


### PR DESCRIPTION
### Summary

- Fixe variable refrences to use `var.` instead of `env.` because they are not really env variables, but variables configured via Terraform for GHA Environments[^1]
[^1]: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#environment-variables

- Fix case when creation of helm chart version fails if repo has no tags, instead default helm chart version to `0.0.0`

### Testing

Now job can be manually triggered for "staging" environment to test:
- https://github.com/gravitational/eks-pod-identity-agent/actions/runs/10681006597
