### PR TITLE
fix: metrics service helmchart

### DIFF
--- a/charts/eks-pod-identity-agent/templates/metrics.yaml
+++ b/charts/eks-pod-identity-agent/templates/metrics.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: eks-pod-identiy-agent
+    {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
       port: {{ .Values.metrics.port }}

--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -35,7 +35,7 @@ metrics:
   path: /metrics
   extraLabels:
     prometheus.io/scrape: "true"
-    prometheus.io/port: 2705
+    prometheus.io/port: "2705"
   serviceMonitor:
     enabled: false
     extraLabels: {}


### PR DESCRIPTION
- Make value of `prometheus.io/port` to be string, otherwise it deployment might fail with:

  ```
  cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string
  ```

- Fix pod selector in metrics service